### PR TITLE
Fix unexpected block tracking and make it an error

### DIFF
--- a/test/errors-src/unexpected-block.pug
+++ b/test/errors-src/unexpected-block.pug
@@ -1,0 +1,4 @@
+extends ../fixtures/empty.pug
+
+block foo
+  div Hello World

--- a/test/errors/unexpected-block.expected.json
+++ b/test/errors/unexpected-block.expected.json
@@ -1,0 +1,5 @@
+{
+  "msg": "Unexpected block foo",
+  "code": "PUG:UNEXPECTED_BLOCK",
+  "line": 3
+}

--- a/test/errors/unexpected-block.input.json
+++ b/test/errors/unexpected-block.input.json
@@ -1,0 +1,58 @@
+{
+  "type": "Block",
+  "nodes": [
+    {
+      "type": "Extends",
+      "file": {
+        "type": "FileReference",
+        "path": "../fixtures/empty.pug",
+        "line": 1,
+        "filename": "unexpected-block.pug",
+        "fullPath": "../fixtures/empty.pug",
+        "str": "",
+        "ast": {
+          "type": "Block",
+          "nodes": [],
+          "line": 0,
+          "filename": "../fixtures/empty.pug"
+        }
+      },
+      "line": 1,
+      "filename": "unexpected-block.pug"
+    },
+    {
+      "type": "NamedBlock",
+      "nodes": [
+        {
+          "type": "Tag",
+          "name": "div",
+          "selfClosing": false,
+          "block": {
+            "type": "Block",
+            "nodes": [
+              {
+                "type": "Text",
+                "val": "Hello World",
+                "line": 4,
+                "filename": "unexpected-block.pug"
+              }
+            ],
+            "line": 4,
+            "filename": "unexpected-block.pug"
+          },
+          "attrs": [],
+          "attributeBlocks": [],
+          "isInline": false,
+          "line": 4,
+          "filename": "unexpected-block.pug"
+        }
+      ],
+      "line": 3,
+      "filename": "unexpected-block.pug",
+      "name": "foo",
+      "mode": "replace"
+    }
+  ],
+  "line": 0,
+  "filename": "unexpected-block.pug"
+}

--- a/test/update-test-cases.js
+++ b/test/update-test-cases.js
@@ -132,6 +132,8 @@ function updateDirErrored (outDir, originalFileDir, inputFiles) {
         link(actualInputAst);
         success = true;
       } catch (ex) {
+        if (!ex.code || ex.code.indexOf('PUG') !== 0) throw ex;
+        console.error(ex.stack);
         fs.writeFileSync(outDir + '/' + expectedName, JSON.stringify({
           msg:  ex.msg,
           code: ex.code,


### PR DESCRIPTION
This fixes the issue where the unexpected block warning did not include any info about block name, line number or file name.

It also makes the unexpected block warning into an error, since we had already said we would do that as part of the 2.0.0 release and complaints were fairly minimal.

[closes pugjs/pug#2391]
